### PR TITLE
Add Wigner-Eckart theorem kernel and extract ci information from mc objects

### DIFF
--- a/fcisiso.py
+++ b/fcisiso.py
@@ -21,6 +21,7 @@ from pyscf import fci, mcscf
 from pyscf.data import nist
 import numpy as np
 import copy
+import py3nj
 
 
 def _print_matrix(mat):
@@ -399,5 +400,163 @@ class FCISISO:
             iv = np.argmax(np.abs(shvec))
             print('  State %4d Total energy: %15.8f | largest |coeff|**2 %10.6f from I = %4d E = %15.8f S = %4.1f'
                   % (i, heig[i], shvec[iv], iv, ess[iv][0], ess[iv][1] / 2))
+        self.energies = heig
+        return heig
+
+    def kernel_we(self, hsoao=None, dmao=None, amfi=True):
+        """
+        State-Interaction using Wigner-Eckart theorem.
+
+        If self.ci is None, the states will be calculated using FCI or CASCI
+        self.ci can also be set manually before calling this method,
+        to skip the FCI or CASCI step.
+
+        self.ci : list((na, nb, 2S, 2MS, energy, ci vector))
+            where :
+                na : number of alpha electrons
+                nb : number of beta electrons
+                2S : 2 times total spin
+                2MS : 2 times projected spin
+                ci vector : 2-dim np.array with shape
+                    (n_det_alpha, n_det_beta)
+
+        Args:
+            hsoao : np.ndarray((3, nao, nao)) or None
+                Hso integral in AO basis
+                if None, it will be calculated using pyscf
+
+            dmao : np.ndarray((n_all_orbs, n_all_orbs)) or None
+                1pdm of ground state, in AO basis
+                used for calculating hsoao
+
+            amfi : bool
+                whether amfi should be used for calculating hsoao
+                for large number of atoms, using amfi can significantly
+                save hsoao computing time
+                if amfi == False, a full
+                np.ndarray((3, nao, nao, nao, nao)) is generated as
+                an intermediate.
+
+        Returns:
+            list(float) : Energy eigenstates with SOC
+        """
+        if self.ci is None or len(self.ci) == 0:
+            raise NotImplementedError
+        if hsoao is None:
+            print('\nGenerating Spin-Orbit Integrals:\n')
+            gsci = 0
+            for ici, ci in enumerate(self.ci):
+                if ci[4] < self.ci[gsci][4]:
+                    gsci = ici
+            if dmao is None:
+                dmao = self.ff.make_rdm1(
+                    self.ci[gsci][-1], self.mol.nao, self.ci[gsci][:2])
+            hsoao = compute_hso_ao(self.mol, dmao, amfi=amfi) * 2
+        hso = np.einsum('rij,ip,jq->rpq', hsoao,
+                        self.mo_coeff[:, self.ncore:self.ncore + self.norb],
+                        self.mo_coeff[:, self.ncore:self.ncore + self.norb])
+        hso_pmz = np.zeros_like(hso)
+        hso_pmz[0] = (1j*hso[1] - hso[0])/2
+        hso_pmz[1] = (1j*hso[1] + hso[0])/2
+        hso_pmz[2] = hso[2]*np.sqrt(0.5)
+
+        # state interaction
+        #
+        ms_dim = [ci[2]+1 for ci in self.ci]
+        idx_shift = [sum(ms_dim[:i]) for i in range(len(ms_dim))]
+        hdiag = np.array([ci[4] for ci in self.ci for ms in range(ci[2]+1)], dtype=complex)
+        hsiso = np.zeros((hdiag.shape[0], hdiag.shape[0]), dtype=complex)
+        thrds = 29.0  # cm-1
+        au2cm = nist.HARTREE2J / nist.PLANCK / nist.LIGHT_SPEED_SI * 1e-2
+        print("\nComplex SO-Hamiltonian matrix elements over spin components of spin-free eigenstates:")
+        print("(In cm-1. Print threshold:%10.3f cm-1)\n" % thrds)
+        for istate, ici in enumerate(self.ci):
+            for jstate, jci in enumerate(self.ci):
+                if jstate < istate:
+                    continue
+                zero_me_ij = False
+                if abs(ici[2]-jci[2]) > 2:
+                    # print("deltaS > 1")
+                    zero_me_ij = True
+                elif ici[2] == jci[2] == 0:
+                    # print("Si = Sj = 0")
+                    zero_me_ij = True
+                elif abs(ici[3]-jci[3]) > 2:
+                    # print("deltaSz > 1")
+                    zero_me_ij = True
+                elif jci[3] == ici[3] - 2:
+                    # print("Tp1")
+                    CGcoeff = py3nj.clebsch_gordan(ici[2], 2, jci[2], ici[3], -2, jci[3])
+                    if CGcoeff == 0:
+                        # print(f"CG zero {ici[2]} {ici[3]} {jci[2]} {jci[3]}")
+                        zero_me_ij = True
+                    else:
+                        tp1 = make_trans(1, ici[-1], jci[-1],
+                                         self.norb, ici[:2], jci[:2])
+                        ij_red_den = tp1 / CGcoeff
+                elif jci[3] == ici[3] + 2:
+                    # print("Tm1")
+                    CGcoeff = py3nj.clebsch_gordan(ici[2], 2, jci[2], ici[3], 2, jci[3])
+                    if CGcoeff == 0:
+                        # print(f"CG zero {ici[2]} {ici[3]} {jci[2]} {jci[3]}")
+                        zero_me_ij = True
+                    else:
+                        tm1 = make_trans(-1, ici[-1], jci[-1],
+                                         self.norb, ici[:2], jci[:2])
+                        ij_red_den = tm1 / CGcoeff
+                elif jci[3] == ici[3]:
+                    # print("Tz")
+                    CGcoeff = py3nj.clebsch_gordan(ici[2], 2, jci[2], ici[3], 0, jci[3])
+                    if CGcoeff == 0:
+                        # print(f"CG zero {ici[2]} {ici[3]} {jci[2]} {jci[3]}")
+                        zero_me_ij = True
+                    else:
+                        tze = make_trans(0, ici[-1], jci[-1],
+                                         self.norb, ici[:2], jci[:2])
+                        ij_red_den = tze / CGcoeff
+                else:
+                    # print("zero")
+                    zero_me_ij = True
+                for ii, i_ms2 in enumerate(range(-ici[2], ici[2] + 1, 2)):
+                    for jj, j_ms2 in enumerate(range(-jci[2], jci[2] + 1, 2)):
+                        if zero_me_ij or abs(i_ms2 - j_ms2) > 2 :
+                            somat = 0
+                        elif j_ms2 == i_ms2 - 2:
+                            CGcoeff = py3nj.clebsch_gordan(ici[2], 2, jci[2], i_ms2, -2, j_ms2)
+                            somat = np.einsum('ij,ij->', ij_red_den, hso_pmz[0])*CGcoeff
+                        elif j_ms2 == i_ms2 + 2:
+                            CGcoeff = py3nj.clebsch_gordan(ici[2], 2, jci[2], i_ms2, 2, j_ms2)
+                            somat = np.einsum('ij,ij->', ij_red_den, hso_pmz[1])*CGcoeff
+                        elif j_ms2 == i_ms2:
+                            CGcoeff = py3nj.clebsch_gordan(ici[2], 2, jci[2], i_ms2, 0, j_ms2)
+                            somat = np.einsum('ij,ij->', ij_red_den, hso_pmz[2])*CGcoeff
+                        else:
+                            # print(f"Hmm, zero {ici[2]} {i_ms2} {jci[2]} {j_ms2}")
+                            somat = 0
+                        hsiso[idx_shift[istate]+ii, idx_shift[jstate]+jj] = somat
+                        if istate != jstate:
+                            hsiso[idx_shift[jstate]+jj, idx_shift[istate]+ii] = np.conj(somat)
+                        somat *= au2cm
+                        if abs(somat) > thrds:
+                            print(('<%4d|H_SO|%4d> I1 = %4d (E1 = %15.8f) S1 = %4.1f MS1 = %4.1f '
+                                   + 'I2 = %4d (E2 = %15.8f) S2 = %4.1f MS2 = %4.1f '
+                                   + 'Re = %9.3f Im = %9.3f')
+                                  % (idx_shift[istate]+ii, idx_shift[jstate]+jj,
+                                     istate, ici[4], ici[2] / 2, i_ms2 / 2,
+                                     jstate, jci[4], jci[2] / 2, j_ms2 / 2,
+                                     somat.real, somat.imag))
+        # Full SISO Hamiltonian eigen states
+        hfull = hsiso + np.diag(hdiag)
+        heig, hvec = np.linalg.eigh(hfull)
+        print('\nTotal energies including SO-coupling:\n')
+        for i in range(len(heig)):
+            sf_proj_vec = []
+            for ibra, mult in enumerate(ms_dim):
+                sf_proj_vec.append(np.linalg.norm(
+                    hvec[idx_shift[ibra]:idx_shift[ibra] + mult, i]) ** 2)
+            iv = np.argmax(np.abs(sf_proj_vec))
+            print(('  State %4d Total energy: %15.8f | largest |proj_norm|**2 % 6.4f '
+                   + 'from I = %4d E = %15.8f S = %4.1f')
+                  % (i, heig[i], sf_proj_vec[iv], iv, self.ci[iv][4], self.ci[iv][2] / 2))
         self.energies = heig
         return heig

--- a/fcisiso.py
+++ b/fcisiso.py
@@ -99,8 +99,10 @@ def make_trans_rdm1(dspin, cibra, ciket, norb, nelec_bra, nelec_ket):
         cond = nelabra == nelaket - 1 and nelbbra == nelbket + 1
     elif dspin == 'ab':
         cond = nelabra == nelaket + 1 and nelbbra == nelbket - 1
+    elif dspin == 'aa':
+        cond = nelabra == nelaket and nelbbra == nelbket and nelabra > 0
     else:
-        cond = nelabra == nelaket and nelbbra == nelbket
+        cond = nelabra == nelaket and nelbbra == nelbket and nelbbra > 0
     if not cond:
         return np.array(0)
     nabra = fci.cistring.num_strings(norb, nelabra)

--- a/fcisiso.py
+++ b/fcisiso.py
@@ -357,15 +357,19 @@ class FCISISO:
             shvec = []
             ess = []
             imb = 0
-            for ibra in range(len(self.states)):
-                mult = self.states[ibra][1]
-                nr = self.states[ibra][0]
-                for ir in range(nr):
-                    shvec.append(np.linalg.norm(
-                        hvec[imb + ir:imb + ir + mult * nr:nr, i]) ** 2)
-                    ess.append((self.ci[imb + ir][4], mult - 1))
-                imb += mult * nr
-            assert imb == len(heig)
+            if self.states is None:
+                shvec = np.abs(hvec[:, i] ** 2)
+                ess = [(vec[4], vec[2]) for vec in self.ci]
+            else:
+                for ibra in range(len(self.states)):
+                    mult = self.states[ibra][1]
+                    nr = self.states[ibra][0]
+                    for ir in range(nr):
+                        shvec.append(np.linalg.norm(
+                            hvec[imb + ir:imb + ir + mult * nr:nr, i]) ** 2)
+                        ess.append((self.ci[imb + ir][4], mult - 1))
+                    imb += mult * nr
+                assert imb == len(heig)
             iv = np.argmax(np.abs(shvec))
             print('  State %4d Total energy: %15.8f | largest |coeff|**2 %10.6f from I = %4d E = %15.8f S = %4.1f'
                   % (i, heig[i], shvec[iv], iv, ess[iv][0], ess[iv][1] / 2))

--- a/tests/12-ru-casscf.py
+++ b/tests/12-ru-casscf.py
@@ -64,3 +64,8 @@ energies = siso.kernel(dmao=dmao, amfi=True)
 
 print(energies)
 print("For time being only one Ms component per state is interacting")
+
+energies = siso.kernel_we(dmao=dmao, amfi=True)
+
+print(energies)
+print("With Wigner-Eckart theorem one Ms component per state is enough to compute all couplings")

--- a/tests/12-ru-casscf.py
+++ b/tests/12-ru-casscf.py
@@ -1,0 +1,66 @@
+
+"""
+Ru 4+ ion in octahedral crystal field CAS(4e, 5o)
+"""
+
+import os
+import sys
+
+sys.path[:0] = [os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), "..")]
+
+from pyscf import gto, scf, mcscf, fci
+from pyscf.qmmm import mm_charge
+from fcisiso import FCISISO, extract_ci_list
+import numpy as np
+
+mol = gto.M(atom='Ru 0 0 0',
+            symmetry=False,
+            basis='ano@6s5p3d',
+            spin=0, charge=4, verbose=4)
+dist = 1.5
+chrg = -2.0
+p_xyz = [[-dist, 0.0, 0.0], [dist, 0.0, 0.0],          
+         [0.0, -dist, 0.0], [0.0, dist, 0.0],
+         [0.0, 0.0, -dist], [0.0, 0.0, dist]]
+p_chr = [chrg]*len(p_xyz)
+
+mf = scf.newton(mm_charge(scf.RHF(mol), p_xyz, p_chr).sfx2c1e()).run(conv_tol=1e-10)
+
+(ncaselec, ncas) = (4, 5)
+ncore = (mol.nelectron - ncaselec) // 2
+ci_tol = 1e-14
+mySpins = [2, 0, 4]
+myStates = [3, 6, 2]
+nstates = sum(myStates)
+weights = [1/nstates]*nstates
+
+solver_list = []
+states_list = []
+for spin, states in zip(mySpins, myStates):
+    solver = fci.direct_spin1.FCI(mol)
+    solver.spin = spin
+    solver.nroots = states
+    solver.conv_tol = ci_tol
+    s_square = (solver.spin/2)*(solver.spin/2 + 1)
+    solver = fci.addons.fix_spin_(solver, ss=s_square, shift=1.5)
+    solver_list.append(solver)
+    states_list.append((states, spin+1))
+
+print('ncore = ', ncore, ' ncas = ', ncas)
+
+mc = mcscf.CASCI(mf, ncas, ncaselec)
+mcscf.state_average_mix_(mc, solver_list, weights)
+mc.kernel()
+
+dmao = mc.make_rdm1()
+ci_list = extract_ci_list(mc)
+
+siso = FCISISO(mol, mc)
+siso.ci = ci_list
+siso.ncore = ncore
+siso.norb = ncas
+energies = siso.kernel(dmao=dmao, amfi=True)
+
+print(energies)
+print("For time being only one Ms component per state is interacting")


### PR DESCRIPTION
The implementation more or less follows https://doi.org/10.1063/1.4927785 and ensures consistency with original implementation with respect to SO energies. 

With WE theorem it is much easier to apply SISO, as only one state is needed.
For now the external py3nj library is expected to be present.